### PR TITLE
Fix #1: Changed :afer content for breadcrumb seperator

### DIFF
--- a/TUD-Responsive.css
+++ b/TUD-Responsive.css
@@ -236,9 +236,9 @@ a {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	display: inline-block;
-	content: "";
+	content: "";
 	color: #999;
-	margin: 0 0 0 .25rem;
+	margin: 0 0 0 .6em;
 	position: absolute;
 	font-size: 1.3rem;
 	vertical-align: middle;


### PR DESCRIPTION
The unicode character used to seperate the breadcrumb seems to have changed in the tud-icon font.

This fixes issue #1.