### PR TITLE
Fix issue #3: last breadcrumb seperated

### DIFF
--- a/TUD-Responsive.css
+++ b/TUD-Responsive.css
@@ -245,6 +245,10 @@ a {
 	pointer-events: none;
 }
 
+#breadcrumbs ul li:last-of-type::after {
+  display: none;
+}
+
 #main {
 	background: #fff;
 	max-width: 960px;


### PR DESCRIPTION
Hiding `:after` of the last `li` in the list.

This fixes #3